### PR TITLE
docs: Swagger, credenciais e roteiro de apresentação

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,32 @@ cp apps/frontend/.env.local.example apps/frontend/.env.local
 npm run docker:up
 ```
 
-Acesse: **http://localhost:3000** (frontend) | **http://localhost:3001/api/docs** (Swagger)
+Acesse:
 
-### 🔑 Perfis de teste (modo bypass)
+| Serviço | URL local | URL produção |
+|---|---|---|
+| Frontend (Next.js) | http://localhost:3000 | https://app-devai-frontend.vercel.app |
+| Backend API | http://localhost:3333/api | https://app-devai-backend.vercel.app/api |
+| **Swagger (OpenAPI)** | http://localhost:3333/api/docs | https://app-devai-backend.vercel.app/api/docs |
+| Health check | http://localhost:3333/api/health | https://app-devai-backend.vercel.app/api/health |
+
+### 📖 Swagger / OpenAPI
+
+O backend expõe toda a API em **Swagger UI** em `/api/docs` — útil pra explorar endpoints, ver schemas de request/response e testar chamadas diretamente pelo navegador.
+
+Principais grupos de endpoints documentados:
+- `professionals` — busca de profissionais, dashboard
+- `orders` — pedidos de materiais (isolados por cliente)
+- `works` — obras (iniciar, atualizar progresso, concluir)
+- `visits` — visitas técnicas (agendar, cancelar, concluir)
+- `material-lists` / `messages` / `conversations` — fluxo de cotação
+- `ai` — geração de cotação por IA
+- `health` — healthcheck
+- `webhooks` — integração Clerk
+
+---
+
+### 🔑 Perfis de teste (modo bypass — ambiente LOCAL)
 
 No ambiente local (`DISABLE_CLERK_AUTH=true`), o usuário logado é escolhido pela env `NEXT_PUBLIC_BYPASS_USER_CLERK_ID` no frontend ou pelo header `X-Dev-User-Id` no backend. Perfis disponíveis no seed:
 
@@ -90,6 +113,31 @@ No ambiente local (`DISABLE_CLERK_AUTH=true`), o usuário logado é escolhido pe
 | `demo_client_001` (default) | Carlos Alberto | client |
 | `demo_client_002` | Joana Mendes | client |
 | `demo_professional_001` | Ricardo Silva | professional |
+| `demo_professional_002` | José da Silva | professional |
+| `demo_professional_003` | Ana Rodrigues | professional |
+
+### 🧪 Credenciais de avaliação (ambiente de PRODUÇÃO)
+
+Em produção o Clerk está ativo e não usa bypass. Para avaliação pela banca, o time cria duas contas reais seguindo o processo abaixo.
+
+#### Como criar um usuário **cliente**
+1. Abrir https://app-devai-frontend.vercel.app/sign-up
+2. Cadastrar com email e senha (verificação por email do Clerk)
+3. O backend faz JIT provisioning (ou o webhook do Clerk) e cria um profile com `role='client'` automaticamente
+4. A conta já tem acesso a `/pedidos`, `/cotacao/ia`, `/busca`
+
+#### Como criar um usuário **profissional**
+1. Seguir os passos 1–3 acima (criar conta via sign-up)
+2. Entrar em https://dashboard.clerk.com → **Users** → selecionar o usuário
+3. Em **Public metadata**, definir:
+   ```json
+   { "role": "professional" }
+   ```
+4. Salvar. O webhook `user.updated` atualiza `profiles.role` no banco
+5. Deslogar e logar novamente
+6. A conta passa a ter acesso a `/profissional/dashboard` (com ações de iniciar/concluir obra e concluir/cancelar visitas)
+
+> **Observação para o time**: as credenciais reais (email/senha) não ficam versionadas neste repositório — são entregues à banca via canal seguro (chat do Canvas, etc.).
 
 ---
 

--- a/docs/roteiro-apresentacao-professor.md
+++ b/docs/roteiro-apresentacao-professor.md
@@ -1,0 +1,255 @@
+# Roteiro de Apresentação — Obra Fácil (Entrega G2)
+
+**Público:** Professor da disciplina de Engenharia de Software — PUC-MG, 2026/1.
+**Duração sugerida:** 15–20 minutos.
+**Formato:** demo ao vivo do produto + walkthrough do código quando fizer sentido.
+
+Este roteiro guia a apresentação endereçando, item por item, a rubrica da Entrega G1 (nota inicial **45/100**) e mostrando como cada ponto foi endereçado na G2. Mantém o tom direto: produto funcionando primeiro, explicação por cima.
+
+---
+
+## 0. Setup antes da apresentação
+
+**Abas do navegador prontas:**
+1. https://app-devai-frontend.vercel.app (frontend)
+2. https://app-devai-backend.vercel.app/api/docs (Swagger)
+3. https://app-devai-backend.vercel.app/api/health (saúde)
+4. GitHub do projeto: https://github.com/lexcesar/obra-facil
+5. Aba com `docs/gap-analysis-entrega-g1.md` aberto (mostra a análise honesta dos gaps da G1)
+6. Aba com `docs/entrega-g2-implementacao.md` aberto (mapeia rubrica → implementação)
+
+**Login nas 2 contas preparadas:**
+- Sessão 1 do browser: cliente
+- Sessão 2 (janela anônima): profissional
+
+**Faça um smoke test 15 minutos antes.** Garante que backend + frontend estão verdes, credenciais funcionam, e `ANTHROPIC_API_KEY` está ativa em produção (teste a cotação com IA).
+
+---
+
+## 1. Abertura (1 min)
+
+> "Na G1 tiramos 45/100. A banca apontou bug em 'Meus Pedidos', ausência de fluxo profissional, ausência de IA real, faltavam observabilidade, testes e IaC. Vamos mostrar como cada ponto foi endereçado."
+
+Mostrar rapidamente o `docs/gap-analysis-entrega-g1.md` para evidenciar que o time **leu a rubrica, classificou cada item e priorizou por esforço × impacto**.
+
+---
+
+## 2. RF1 — Meus Pedidos (bug crítico) (2 min)
+
+**Observação original da banca:** *"Histórico traz dados de outros usuários."*
+
+### Demo
+1. Fazer login como **cliente A**
+2. Entrar em `/pedidos` — mostrar que lista pedidos (se houver no banco de prod)
+3. Abrir `docs/plans/2026-04-18-001-fix-meus-pedidos-isolamento-usuario-plan.md` brevemente para mostrar a análise do root cause
+
+### O que dizer
+> "O bug estava no `ClerkAuthGuard` em modo bypass: retornava o primeiro perfil do banco sem `ORDER BY`, colapsando todos os usuários no mesmo `profile.id`. Corrigimos com resolução determinística via header `X-Dev-User-Id` e `ORDER BY` no fallback, além de adicionar JIT provisioning idempotente com o webhook Clerk."
+
+### Evidências
+- Commit: `apps/backend/src/core/guards/clerk-auth.guard.ts`
+- Testes: `apps/backend/test/orders.e2e-spec.ts` — cenários de isolamento bidirecional contra Postgres real
+- CI roda esses testes a cada push
+
+---
+
+## 3. RF2 — Fluxo profissional (3 min)
+
+**Observação original:** *"Pendente disponibilizar credenciais com perfil do profissional."*
+
+### Demo
+1. Trocar para a sessão do **profissional**
+2. Entrar em `/profissional/dashboard`
+3. Mostrar os 4 cards de stats (visitas, obras ativas, conversas, concluídas)
+4. Se houver obra agendada: clicar **Iniciar obra** → mostrar transição
+5. Se houver obra ativa: clicar **Marcar como concluída** → mostrar transição + `progress_pct=100`
+6. Se houver visita confirmada: clicar **Concluir** ou **Cancelar**
+
+### O que dizer
+> "O profissional tem um dashboard com stats e ações ponta-a-ponta. Cada ação é protegida por um guard que confere `role='professional'` **e** que o recurso pertence ao profissional logado — dois profissionais não conseguem mexer na obra um do outro."
+
+### Evidências no Swagger
+Abrir https://app-devai-backend.vercel.app/api/docs:
+- `GET /v1/professionals/me/dashboard`
+- `PATCH /v1/works/:id/start`, `PATCH /v1/works/:id/complete`, `PATCH /v1/works/:id/progress`
+- `PATCH /v1/visits/:id/cancel`, `PATCH /v1/visits/:id/complete`
+
+---
+
+## 4. RF3 — Tecnologia de fronteira (IA) (3 min)
+
+**Observação original:** *"Nenhuma tecnologia avançada implementada."*
+
+### Demo
+1. Ainda como cliente, acessar `/cotacao/ia`
+2. Digitar: **"Reformar banheiro pequeno de 4m² com troca de piso, azulejo, louças e metais"**
+3. Clicar **Gerar lista de materiais**
+4. Aguardar ~5 segundos
+5. Mostrar a lista gerada (20+ itens realistas com quantidades, unidades e categorias)
+
+### O que dizer
+> "Integração **real** com Anthropic Claude Haiku 4.5 — não é mock. O prompt é especialista em materiais de construção civil no Brasil. Resposta validada por schema JSON, itens categorizados, observações contextuais. Tudo logado com tokens usados via Pino."
+
+### Evidências
+- `apps/backend/src/modules/ai/ai.service.ts`
+- Teste unitário com mock do SDK: `ai.service.spec.ts`
+- Swagger: `POST /v1/ai/material-quote`
+- No health check: `env: production`
+
+---
+
+## 5. RNF-04 — Observabilidade (1 min)
+
+### Demo
+1. Abrir https://app-devai-backend.vercel.app/api/health
+2. Mostrar a resposta JSON:
+   ```json
+   {
+     "data": {
+       "status": "ok",
+       "db": "ok",
+       "uptime_s": 264,
+       "response_ms": 617,
+       "version": "dev",
+       "env": "production",
+       "timestamp": "..."
+     }
+   }
+   ```
+
+### O que dizer
+> "Endpoint `/api/health` testa a conexão real com o banco. Logs estruturados em JSON via `nestjs-pino`, com request ID automático para correlação e redact de cabeçalhos sensíveis (Authorization, Cookie, X-Dev-User-Id)."
+
+### Evidência no código
+- `apps/backend/src/app.module.ts` — configuração do Pino com redact
+- `apps/backend/src/modules/health/health.controller.ts`
+
+---
+
+## 6. RNF-05 — Testabilidade (2 min)
+
+**De 1 teste placeholder (Hello World) para 68 testes.**
+
+### Demo
+No terminal (pré-aquecido):
+```bash
+npm test --workspace=backend          # 49 testes Jest em ~0.5s
+npm test --workspace=frontend         # 9 testes Vitest em ~0.8s
+```
+
+Ou abrir o CI: https://github.com/lexcesar/obra-facil/actions — mostrar o último run verde.
+
+### O que dizer
+> "Quatro frameworks, cada um no seu lugar:
+> - **Jest** para unit e integração do backend (49 + 6 e2e).
+> - **Vitest + Testing Library** para unit do frontend (9).
+> - **Playwright** para e2e browser (4).
+> - Tudo roda no CI a cada push, incluindo container Postgres com schema e seed aplicados."
+
+### Evidência
+- `.github/workflows/ci.yml`
+- `docs/entrega-g2-implementacao.md` seção RNF-05 com breakdown por arquivo
+
+---
+
+## 7. RNF-06 — IaC (1 min)
+
+**Observação original:** *"Artefatos IaC não identificados."*
+
+### O que dizer
+> "Três camadas de IaC:
+> 1. **Containers OCI** (Dockerfile + docker-compose) para runtime local/self-hosted
+> 2. **Schema SQL versionado** (`docker/01-schema.sql`, `docker/02-seed.sql`) — banco reproduzível
+> 3. **Terraform** em `infra/terraform/vercel/` declarando os dois projetos Vercel (backend + frontend) com env vars e integração GitHub"
+
+### Evidência
+- Mostrar `infra/terraform/vercel/main.tf`
+- Mostrar `docs/terraform-plan-output.txt` — saída real do `terraform plan` comprovando que a declaração é válida
+
+---
+
+## 8. Segurança reforçada (1 min, bônus)
+
+Na mesma rodada de correções:
+- **Startup guard** (`apps/backend/src/main.ts`): backend aborta com exit 1 se `NODE_ENV=production` e `DISABLE_CLERK_AUTH=true` simultaneamente
+- **Error messages sanitizadas**: 401 devolve `"Não autorizado"` sem vazar `clerk_id` tentado (evita enumeração)
+- **Header X-Dev-User-Id**: ignorado em produção por verificação dupla de env var
+
+> "Esses são bônus que vieram de um code review adversarial automatizado — o time roda reviews estruturados antes de cada PR."
+
+---
+
+## 9. Processo de engenharia (1 min)
+
+Mostrar rapidamente o GitHub do projeto:
+- PRs #36, #37, #38 (linha do tempo de como a G2 foi entregue)
+- Histórico de commits com Conventional Commits
+- CI badge verde
+- Plano detalhado versionado em `docs/plans/`
+
+> "A entrega foi estruturada como três PRs incrementais: o primeiro fecha o bug crítico + 5 dos 6 itens da rubrica, o segundo completa o fluxo profissional com ações, o terceiro adiciona o artefato de Terraform plan. Cada PR passa pela mesma pipeline."
+
+---
+
+## 10. Fechamento (1 min)
+
+Tabela resumo (`docs/entrega-g2-implementacao.md` tem isso ao final):
+
+| Antes (G1) | Depois (G2) |
+|---|---|
+| 45/100 pontos | Potencial ~100/100 |
+| 1 teste | 68 testes em 4 frameworks |
+| Logs `console.log` | Pino JSON + requestId + redact |
+| Sem IaC | Terraform + Docker + SQL |
+| Sem IA | Claude Haiku 4.5 integrado |
+| Bug crítico em Meus Pedidos | Corrigido + testes de isolamento |
+| Sem dashboard profissional | Dashboard + ações ponta-a-ponta |
+
+> "Recap rápido: endereçamos os seis gaps apontados pela banca; as implementações estão em produção na Vercel e o código tem 68 testes automatizados. Qualquer pergunta?"
+
+---
+
+## Perguntas prováveis da banca + respostas prontas
+
+**P: "O webhook do Clerk está funcionando em produção?"**
+R: Sim. `CLERK_WEBHOOK_SECRET` está configurado no Vercel. Temos JIT provisioning como fallback no `ClerkAuthGuard` caso o webhook falhe ou demore.
+
+**P: "Como vocês garantem que o usuário A não vê pedidos do B?"**
+R: Três camadas: (1) SQL com `WHERE client_id = $1`; (2) `OrdersController` exige `role='client'` e passa `profile.id` do guard; (3) teste e2e em `orders.e2e-spec.ts` prova isolamento bidirecional contra Postgres real.
+
+**P: "A IA pode inventar coisas (alucinar)?"**
+R: Sim, é um risco inerente. Mitigações: prompt sistêmico estrito em português, schema JSON validado no backend, descrição limitada a 2000 caracteres. Para MVP é aceitável; próximo passo seria adicionar price grounding contra as lojas reais.
+
+**P: "Por que Terraform só para Vercel e não Supabase?"**
+R: O provider oficial do Supabase gerencia apenas projeto/branches — não cria tabelas, RLS ou schemas. Como o schema já está versionado em `docker/01-schema.sql`, o ganho marginal não compensa a complexidade adicional. Decisão documentada no plan.
+
+**P: "Como escalariam para mil usuários?"**
+R: Vercel serverless escala horizontal automático. Supabase pooler suporta até ~200 conexões simultâneas no free tier. Cache aggressive para leituras de profissionais (30s+). Próximos gargalos seriam: IA latency (mover pra fila/SSE) e cold starts.
+
+**P: "Onde está o monitoramento de erros (Sentry, DataDog)?"**
+R: Não temos APM externo — usamos Pino com JSON logs que a Vercel agrega. Para próximas iterações, `nestjs-pino` já exporta para qualquer OTLP collector.
+
+**P: "Vocês usaram alguma LLM para gerar o código?"**
+R: Sim — Claude Code como par de programação. Todos os PRs passaram por revisão humana, CI, e a arquitetura foi decidida pelo time. A IA acelerou implementação, não substituiu decisões.
+
+---
+
+## Se algo falhar durante a demo
+
+- **Backend 500**: verificar `https://app-devai-backend.vercel.app/api/health` — se DB estiver down, plano B é fazer o passeio pelo Swagger + código
+- **IA demora ou trava**: mostrar log de chamada no Vercel + cache de response de uma execução anterior (screenshot)
+- **Login Clerk trava**: usar a aba já logada que você preparou no setup
+- **Vercel rollback necessário**: `git revert` + push; deploy novo em ~1min
+
+---
+
+## Artefatos para entregar junto
+
+1. **Link do repositório**: https://github.com/lexcesar/obra-facil
+2. **URL da aplicação**: https://app-devai-frontend.vercel.app
+3. **Credenciais** (cliente + profissional — entregar por canal seguro, não neste doc)
+4. **Esta pasta de docs**: `docs/` contém gap analysis, plano técnico, mapeamento rubrica→implementação, terraform plan, roteiro desta apresentação
+
+---
+
+*Última atualização: 2026-04-18*


### PR DESCRIPTION
Atualiza o README e adiciona um roteiro de apresentação pro time.

**README**
- Seção dedicada ao Swagger (local + prod) com tabela de URLs
- Tabela de endpoints agrupados
- Processo passo-a-passo para criar conta cliente e profissional em produção (sem emails específicos — entregues por canal seguro)

**Novo doc: docs/roteiro-apresentacao-professor.md**
- Roteiro de 15-20 min para o time apresentar a aplicação
- Endereça cada item da rubrica G1 com demo + evidência no código
- Inclui setup pré-apresentação, perguntas prováveis da banca com respostas preparadas, e plano B se algo falhar ao vivo