### PR TITLE
fix(auth): aguardar Clerk carregar antes de chamar API; fix(configura…

### DIFF
--- a/apps/frontend/src/app/(app)/perfil/configuracoes/page.tsx
+++ b/apps/frontend/src/app/(app)/perfil/configuracoes/page.tsx
@@ -17,6 +17,8 @@ export default async function ConfiguracoesPage() {
   if (!userId) redirect('/sign-in');
 
   const account = await api.get<AccountContext>('/v1/account/me').catch(() => null);
+  const roles = account?.roles ?? [];
+  const actingAs = account?.actingAs ?? 'client';
 
   return (
     <div className="pb-24 bg-surface min-h-screen">
@@ -46,15 +48,18 @@ export default async function ConfiguracoesPage() {
           ))}
         </div>
 
-        {account && <ProfessionalActivation roles={account.roles} />}
-
-        {account && (
-          <RoleSelector currentRole={account.actingAs} availableRoles={account.roles} />
+        {!account && (
+          <p className="text-xs text-amber-600 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2 mt-4">
+            Não foi possível carregar informações da conta. Algumas opções podem estar indisponíveis.
+          </p>
         )}
+
+        <ProfessionalActivation roles={roles} />
+
+        <RoleSelector currentRole={actingAs} availableRoles={roles} />
 
         <p className="text-[10px] text-slate-300 text-center mt-8">Obra Facil v1.0.0</p>
       </div>
     </div>
   );
 }
-

--- a/apps/frontend/src/components/ui/NotificationBell.tsx
+++ b/apps/frontend/src/components/ui/NotificationBell.tsx
@@ -2,7 +2,9 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
+import { useAuth } from '@clerk/nextjs';
 import { useClientApi } from '@/lib/api/client-api';
+import { isAuthBypassEnabled } from '@/lib/auth-bypass-config';
 import type { Notification } from '@obrafacil/shared';
 
 function timeAgo(iso: string): string {
@@ -28,19 +30,23 @@ const TYPE_ICON: Record<string, string> = {
 export function NotificationBell() {
   const router = useRouter();
   const api = useClientApi();
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { isLoaded } = isAuthBypassEnabled ? { isLoaded: true } : useAuth();
   const [open, setOpen] = useState(false);
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  // Fetch unread count on mount and after close
+  // Wait for Clerk to hydrate before making authenticated requests.
+  // Without this guard, getToken() returns null on first render → 401.
   useEffect(() => {
+    if (!isLoaded) return;
     api.get<{ count: number }>('/v1/notifications/count')
       .then((res) => setUnreadCount(res.count))
       .catch(() => {});
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [isLoaded]);
 
   // Close on outside click
   useEffect(() => {


### PR DESCRIPTION
…coes): sempre renderizar toggle profissional

- NotificationBell: adiciona isLoaded do useAuth para evitar 401 no mount antes do Clerk hidratar o token no cliente
- configuracoes/page.tsx: ProfessionalActivation e RoleSelector agora sempre renderizam com fallback roles=[] quando /v1/account/me falha

## Descrição

<!-- Descreva o que este PR faz e por quê. -->

## Tipo de mudança

- [ ] `feat` — Nova funcionalidade
- [ ] `fix` — Correção de bug
- [ ] `refactor` — Refatoração (sem mudança de comportamento)
- [ ] `chore` — Atualização de deps, config, docs
- [ ] `test` — Adição ou correção de testes

## Contexto

<!-- Número da issue relacionada (ex: Closes #42) -->

## Checklist

- [ ] O CI está verde (lint + typecheck + build)
- [ ] Não há `console.log` ou código comentado
- [ ] Não há `any` sem comentário justificando
- [ ] Variáveis de ambiente novas foram documentadas em `docs/variaveis-ambiente.md`
- [ ] Mudanças no schema do banco foram adicionadas em `docker/01-schema.sql`

## Como testar

<!-- Explique os passos para testar manualmente as mudanças. -->

1. `npm run docker:up`
2. Acesse http://localhost:3000
3. ...
